### PR TITLE
Added missing colon so plugin will load

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -6,6 +6,6 @@ version: 1.0.1
 depend: [ SimpleTowns, Vault ]
 dev-url: http://dev.bukkit.org/bukkit-plugins/simpletownseconomy/
 permissions:
-  simpletownseconomy.bypass
+  simpletownseconomy.bypass:
     default: false
     description: Allows a player to bypass charges


### PR DESCRIPTION
This plugin wouldn't load on Spigot 1.7/1.8, it threw a ScannerException because of a missing colon after simpletownseconomy.bypass under permissions.
